### PR TITLE
Bugfix: Fatal error thrown when not on category page

### DIFF
--- a/Observer/Layout/LoadBeforeObserver.php
+++ b/Observer/Layout/LoadBeforeObserver.php
@@ -37,6 +37,10 @@ class LoadBeforeObserver implements ObserverInterface
             return;
         }
 
+        if (empty($this->registry->registry('current_category'))) {
+            return;
+        }
+
         if (ModePlugin::DM_LANDING !== $this->registry->registry('current_category')->getDisplayMode()) {
             return;
         }


### PR DESCRIPTION
Fatal error:
https://github.com/WeareJH/m2-module-landing-categories/issues/1