### PR TITLE
Make landing categories great again (with the ability to configure)

### DIFF
--- a/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
+++ b/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
@@ -3,6 +3,8 @@
 namespace Jh\LandingCategories\Block\Adminhtml\Widget\Instance\Edit\Tab\Main;
 
 use Jh\LandingCategories\Model\Config\Data as LandingCategoryData;
+use Magento\Backend\Block\Template\Context;
+use Magento\Catalog\Model\Product\Type;
 use Magento\Framework\Phrase;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Widget\Block\Adminhtml\Widget\Instance\Edit\Tab\Main\Layout as MainLayout;
@@ -19,8 +21,8 @@ class Layout extends MainLayout
     private $landingCategoryData;
 
     public function __construct(
-        \Magento\Backend\Block\Template\Context $context,
-        \Magento\Catalog\Model\Product\Type $productType,
+        Context $context,
+        Type $productType,
         LandingCategoryData $landingCategoryData,
         array $data = [],
         Json $serializer = null

--- a/Model/Config/Converter.php
+++ b/Model/Config/Converter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Jh\LandingCategories\Model\Config;
+
+use Magento\Framework\Config\ConverterInterface;
+
+class Converter implements ConverterInterface
+{
+    /**
+     * Convert config
+     *
+     * @param \DOMDocument $source
+     * @return array
+     */
+    public function convert($source)
+    {
+        $elems = $source->getElementsByTagName("view");
+        $nodes = $this->convertToArray($elems);
+        $views = \array_map(function (\DOMNode $node) {
+            $attrs = $node->attributes;
+            return [
+                "name" => $attrs->getNamedItem('name')->nodeValue,
+                "label" => $attrs->getNamedItem('label')->nodeValue,
+                "layout" => $attrs->getNamedItem('layout')->nodeValue,
+            ];
+
+        }, $nodes);
+        return $views;
+    }
+
+    private function convertToArray(\DOMNodeList $DOMNodeList)
+    {
+        $nodes = [];
+        for ($i = 0; $i < $DOMNodeList->length; $i++) {
+            $nodes[] = $DOMNodeList->item($i);
+        }
+        return $nodes;
+    }
+}

--- a/Model/Config/Data.php
+++ b/Model/Config/Data.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Jh\LandingCategories\Model\Config;
+
+class Data extends \Magento\Framework\Config\Data
+{
+
+}

--- a/Model/Config/SchemaLocator.php
+++ b/Model/Config/SchemaLocator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jh\LandingCategories\Model\Config;
+
+use Magento\Framework\Config\SchemaLocatorInterface;
+use Magento\Framework\Module\Dir;
+
+class SchemaLocator implements SchemaLocatorInterface
+{
+    /**
+     * Get path to merged config schema
+     *
+     * @return string|null
+     */
+    protected $_schema = null;
+
+    public function __construct(\Magento\Framework\Module\Dir\Reader $moduleReader)
+    {
+        $this->_schema = $moduleReader->getModuleDir(Dir::MODULE_ETC_DIR, 'Jh_LandingCategories') . DIRECTORY_SEPARATOR . 'landing_categories.xsd';
+    }
+
+    public function getSchema()
+    {
+        return $this->_schema;
+    }
+
+    /**
+     * Get path to per file validation schema
+     *
+     * @return string|null
+     */
+    public function getPerFileSchema()
+    {
+        return null;
+    }
+}

--- a/Model/Config/SchemaLocator.php
+++ b/Model/Config/SchemaLocator.php
@@ -4,6 +4,7 @@ namespace Jh\LandingCategories\Model\Config;
 
 use Magento\Framework\Config\SchemaLocatorInterface;
 use Magento\Framework\Module\Dir;
+use Magento\Framework\Module\Dir\Reader;
 
 class SchemaLocator implements SchemaLocatorInterface
 {
@@ -14,7 +15,7 @@ class SchemaLocator implements SchemaLocatorInterface
      */
     protected $_schema = null;
 
-    public function __construct(\Magento\Framework\Module\Dir\Reader $moduleReader)
+    public function __construct(Reader $moduleReader)
     {
         $this->_schema = $moduleReader->getModuleDir(Dir::MODULE_ETC_DIR, 'Jh_LandingCategories') . DIRECTORY_SEPARATOR . 'landing_categories.xsd';
     }

--- a/Model/Widget/Instance.php
+++ b/Model/Widget/Instance.php
@@ -2,8 +2,22 @@
 
 namespace Jh\LandingCategories\Model\Widget;
 
-use Jh\LandingCategories\Model\Config\Data;
+use Jh\LandingCategories\Model\Config\Data as LandingCategoryData;
+use Magento\Catalog\Model\Product\Type;
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\Escaper;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Math\Random;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+use Magento\Framework\Registry;
 use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\View\FileSystem as ViewFileSystemAlias;
+use Magento\Widget\Helper\Conditions;
+use Magento\Widget\Model\Config\Reader;
+use Magento\Widget\Model\NamespaceResolver;
+use Magento\Widget\Model\Widget;
 use Magento\Widget\Model\Widget\Instance as WidgetInstance;
 
 /**
@@ -11,28 +25,27 @@ use Magento\Widget\Model\Widget\Instance as WidgetInstance;
  */
 class Instance extends WidgetInstance
 {
-    const LANDING_CATEGORY_LAYOUT_HANDLE = 'jh_category_landing';
     /**
-     * @var Data
+     * @var LandingCategoryData
      */
     private $landingCategoryData;
 
     public function __construct(
-        \Magento\Framework\Model\Context $context,
-        \Magento\Framework\Registry $registry,
-        \Magento\Framework\Escaper $escaper,
-        \Magento\Framework\View\FileSystem $viewFileSystem,
-        \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
-        \Magento\Catalog\Model\Product\Type $productType,
-        \Magento\Widget\Model\Config\Reader $reader,
-        \Magento\Widget\Model\Widget $widgetModel,
-        \Magento\Widget\Model\NamespaceResolver $namespaceResolver,
-        \Magento\Framework\Math\Random $mathRandom,
-        \Magento\Framework\Filesystem $filesystem,
-        \Magento\Widget\Helper\Conditions $conditionsHelper,
-        \Jh\LandingCategories\Model\Config\Data $landingCategoryData,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        Context $context,
+        Registry $registry,
+        Escaper $escaper,
+        ViewFileSystemAlias $viewFileSystem,
+        TypeListInterface $cacheTypeList,
+        Type $productType,
+        Reader $reader,
+        Widget $widgetModel,
+        NamespaceResolver $namespaceResolver,
+        Random $mathRandom,
+        Filesystem $filesystem,
+        Conditions $conditionsHelper,
+        LandingCategoryData $landingCategoryData,
+        AbstractResource $resource = null,
+        AbstractDb $resourceCollection = null,
         array $relatedCacheTypes = [],
         array $data = [],
         Json $serializer = null

--- a/Model/Widget/Instance.php
+++ b/Model/Widget/Instance.php
@@ -2,6 +2,8 @@
 
 namespace Jh\LandingCategories\Model\Widget;
 
+use Jh\LandingCategories\Model\Config\Data;
+use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Widget\Model\Widget\Instance as WidgetInstance;
 
 /**
@@ -10,11 +12,52 @@ use Magento\Widget\Model\Widget\Instance as WidgetInstance;
 class Instance extends WidgetInstance
 {
     const LANDING_CATEGORY_LAYOUT_HANDLE = 'jh_category_landing';
+    /**
+     * @var Data
+     */
+    private $landingCategoryData;
+
+    public function __construct(
+        \Magento\Framework\Model\Context $context,
+        \Magento\Framework\Registry $registry,
+        \Magento\Framework\Escaper $escaper,
+        \Magento\Framework\View\FileSystem $viewFileSystem,
+        \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
+        \Magento\Catalog\Model\Product\Type $productType,
+        \Magento\Widget\Model\Config\Reader $reader,
+        \Magento\Widget\Model\Widget $widgetModel,
+        \Magento\Widget\Model\NamespaceResolver $namespaceResolver,
+        \Magento\Framework\Math\Random $mathRandom,
+        \Magento\Framework\Filesystem $filesystem,
+        \Magento\Widget\Helper\Conditions $conditionsHelper,
+        \Jh\LandingCategories\Model\Config\Data $landingCategoryData,
+        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        array $relatedCacheTypes = [],
+        array $data = [],
+        Json $serializer = null
+    )
+    {
+        $this->landingCategoryData = $landingCategoryData;
+
+        parent::__construct(
+            $context, $registry, $escaper, $viewFileSystem, $cacheTypeList, $productType, $reader, $widgetModel,
+            $namespaceResolver, $mathRandom, $filesystem, $conditionsHelper, $resource, $resourceCollection,
+            $relatedCacheTypes, $data, $serializer
+        );
+    }
 
     protected function _construct()
     {
         parent::_construct();
-        $this->_layoutHandles['jh_category_landing'] = self::LANDING_CATEGORY_LAYOUT_HANDLE;
-        $this->_specificEntitiesLayoutHandles['jh_category_landing'] = self::SINGLE_CATEGORY_LAYOUT_HANDLE;
+
+        $landingCategoryData = $this->landingCategoryData->get();
+
+        foreach ($landingCategoryData as $data) {
+            $this->_layoutHandles[$data['layout']] = $data['layout'];
+            $this->_specificEntitiesLayoutHandles[$data['layout']] = self::SINGLE_CATEGORY_LAYOUT_HANDLE;
+        }
+
+
     }
 }

--- a/Observer/Layout/LoadBeforeObserver.php
+++ b/Observer/Layout/LoadBeforeObserver.php
@@ -18,10 +18,15 @@ class LoadBeforeObserver implements ObserverInterface
      * @var Registry
      */
     private $registry;
+    /**
+     * @var \Jh\LandingCategories\Model\Config\Data
+     */
+    private $categoryData;
 
-    public function __construct(Registry $registry)
+    public function __construct(Registry $registry, \Jh\LandingCategories\Model\Config\Data $categoryData)
     {
         $this->registry = $registry;
+        $this->categoryData = $categoryData;
     }
 
     /**
@@ -41,10 +46,32 @@ class LoadBeforeObserver implements ObserverInterface
             return;
         }
 
-        if (ModePlugin::DM_LANDING !== $this->registry->registry('current_category')->getDisplayMode()) {
+
+        $displayMode = $this->getCustomLayoutHandle();
+
+        if ($displayMode === null) {
             return;
         }
 
-        $event->getLayout()->getUpdate()->addHandle(self::LANDING_CATEGORY_LAYOUT_HANDLE);
+
+        $event->getLayout()->getUpdate()->addHandle($displayMode['layout']);
+    }
+
+    protected function getCustomLayoutHandle()
+    {
+        $currentCategory = $this->registry->registry('current_category');
+        $displayMode = $currentCategory->getDisplayMode();
+        $categoryData = $this->categoryData->get();
+
+        foreach ($categoryData as $key => $value) {
+            if ($value["name"] === $displayMode) {
+                return $value;
+            }
+        }
+
+        return null;
+        //
+        //    \array_column($currentCategory,)
+
     }
 }

--- a/Observer/Layout/LoadBeforeObserver.php
+++ b/Observer/Layout/LoadBeforeObserver.php
@@ -23,7 +23,10 @@ class LoadBeforeObserver implements ObserverInterface
      */
     private $categoryData;
 
-    public function __construct(Registry $registry, \Jh\LandingCategories\Model\Config\Data $categoryData)
+    public function __construct(
+        Registry $registry,
+        \Jh\LandingCategories\Model\Config\Data $categoryData
+    )
     {
         $this->registry = $registry;
         $this->categoryData = $categoryData;
@@ -46,13 +49,11 @@ class LoadBeforeObserver implements ObserverInterface
             return;
         }
 
-
         $displayMode = $this->getCustomLayoutHandle();
 
         if ($displayMode === null) {
             return;
         }
-
 
         $event->getLayout()->getUpdate()->addHandle($displayMode['layout']);
     }
@@ -68,10 +69,7 @@ class LoadBeforeObserver implements ObserverInterface
                 return $value;
             }
         }
-
         return null;
-        //
-        //    \array_column($currentCategory,)
 
     }
 }

--- a/Observer/Layout/LoadBeforeObserver.php
+++ b/Observer/Layout/LoadBeforeObserver.php
@@ -2,7 +2,7 @@
 
 namespace Jh\LandingCategories\Observer\Layout;
 
-use Jh\LandingCategories\Plugin\Category\Attribute\Source\ModePlugin;
+use Jh\LandingCategories\Model\Config\Data as LandingCategoryData;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Registry;
@@ -12,20 +12,19 @@ use Magento\Framework\Registry;
  */
 class LoadBeforeObserver implements ObserverInterface
 {
-    const LANDING_CATEGORY_LAYOUT_HANDLE = 'jh_category_landing';
 
     /**
      * @var Registry
      */
     private $registry;
     /**
-     * @var \Jh\LandingCategories\Model\Config\Data
+     * @var LandingCategoryData
      */
     private $categoryData;
 
     public function __construct(
         Registry $registry,
-        \Jh\LandingCategories\Model\Config\Data $categoryData
+        LandingCategoryData $categoryData
     )
     {
         $this->registry = $registry;

--- a/Plugin/Category/Attribute/Source/ModePlugin.php
+++ b/Plugin/Category/Attribute/Source/ModePlugin.php
@@ -2,6 +2,7 @@
 
 namespace Jh\LandingCategories\Plugin\Category\Attribute\Source;
 
+use Jh\LandingCategories\Model\Config\Data as LandingCategoryData;
 use Magento\Catalog\Model\Category\Attribute\Source\Mode;
 
 /**
@@ -10,6 +11,15 @@ use Magento\Catalog\Model\Category\Attribute\Source\Mode;
 class ModePlugin
 {
     const DM_LANDING = 'JH_LANDING';
+    /**
+     * @var LandingCategoryData
+     */
+    private $landingCategoryData;
+
+    public function __construct(LandingCategoryData $landingCategoryData)
+    {
+        $this->landingCategoryData = $landingCategoryData;
+    }
 
     /**
      * Add the landing category display mode
@@ -21,8 +31,11 @@ class ModePlugin
     {
         if (is_array($result)) {
             $result[] = ['value' => self::DM_LANDING, 'label' => __('Landing Category')];
+            $catData = $this->landingCategoryData->get();
+            foreach($catData as $option) {
+                $result[] = ['value' => $option['name'], 'label' => $option['label']];
+            }
         }
-
         return $result;
     }
 }

--- a/Plugin/Category/Attribute/Source/ModePlugin.php
+++ b/Plugin/Category/Attribute/Source/ModePlugin.php
@@ -30,9 +30,8 @@ class ModePlugin
     public function afterGetAllOptions(Mode $subject, $result)
     {
         if (is_array($result)) {
-            $result[] = ['value' => self::DM_LANDING, 'label' => __('Landing Category')];
             $catData = $this->landingCategoryData->get();
-            foreach($catData as $option) {
+            foreach ($catData as $option) {
                 $result[] = ['value' => $option['name'], 'label' => $option['label']];
             }
         }

--- a/Plugin/Category/Attribute/Source/ModePlugin.php
+++ b/Plugin/Category/Attribute/Source/ModePlugin.php
@@ -10,7 +10,6 @@ use Magento\Catalog\Model\Category\Attribute\Source\Mode;
  */
 class ModePlugin
 {
-    const DM_LANDING = 'JH_LANDING';
     /**
      * @var LandingCategoryData
      */

--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ A custom handle `jh_category_landing` will be loaded on that category page. Add 
 
 In the admin panel, on the add/edit a widget page, under Layout Updates, set Display on as "Landing Categories", then choose a specific category or check the "all" radio button.
 
+
+
+### (Add your own display modes - from version 1.2.2)
+
+To add your own display modes: 
+- Add this module as a dependency in your own module
+- Create a `landing_categories.xml` within your etc folder of your module
+
+```xml
+<?xml version="1.0"?>
+<config>
+    <view name="jh_test" label="A Double Page" layout="jh_test_layout" /><view name="jh_test2" label="Another Landing Page" layout="jh_mest_layout" />
+</config>
+```
+
 ### Installation
 
 Add the following to your `repositories` key in your `composer.json` file:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In the admin panel, on the add/edit a widget page, under Layout Updates, set Dis
 
 
 
-### (Add your own display modes - from version 1.2.2)
+### (Add your own display modes - from version 1.1.0)
 
 To add your own display modes: 
 - Add this module as a dependency in your own module

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <virtualType name="LandingCategoriesReader" type="Magento\Framework\Config\Reader\Filesystem">
+        <arguments>
+            <argument name="converter" xsi:type="object">Jh\LandingCategories\Model\Config\Converter</argument>
+            <argument name="schemaLocator" xsi:type="object">Jh\LandingCategories\Model\Config\SchemaLocator</argument>
+            <argument name="fileName" xsi:type="string">landing_categories.xml</argument>
+        </arguments>
+    </virtualType>
+    <type name="Jh\LandingCategories\Model\Config\Data">
+        <arguments>
+            <argument name="reader" xsi:type="object">LandingCategoriesReader</argument>
+            <argument name="cacheId" xsi:type="string">jh_landing_categories_cache</argument>
+        </arguments>
+    </type>
+</config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -6,6 +6,9 @@
             <argument name="converter" xsi:type="object">Jh\LandingCategories\Model\Config\Converter</argument>
             <argument name="schemaLocator" xsi:type="object">Jh\LandingCategories\Model\Config\SchemaLocator</argument>
             <argument name="fileName" xsi:type="string">landing_categories.xml</argument>
+            <argument name="idAttributes" xsi:type="array">
+                <item name="/views/view" xsi:type="string">name</item>
+            </argument>
         </arguments>
     </virtualType>
     <type name="Jh\LandingCategories\Model\Config\Data">

--- a/etc/landing_categories.xml
+++ b/etc/landing_categories.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<config>
+<views>
     <view name="JH_CATEGORY" label="A Double Page" layout="jh_test_layout" />
     <view name="jh_test2" label="Another Landing Page" layout="jh_mest_layout" />
-</config>
+</views>

--- a/etc/landing_categories.xml
+++ b/etc/landing_categories.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
-<views>
+<views xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Jh_LandingCategories:etc/landing_categories.xsd">
     <view name="JH_LANDING" label="Landing Category" layout="jh_category_landing" />
 </views>

--- a/etc/landing_categories.xml
+++ b/etc/landing_categories.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<config>
+    <view name="JH_CATEGORY" label="A Double Page" layout="jh_test_layout" />
+    <view name="jh_test2" label="Another Landing Page" layout="jh_mest_layout" />
+</config>

--- a/etc/landing_categories.xml
+++ b/etc/landing_categories.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0"?>
 <views>
-    <view name="JH_CATEGORY" label="A Double Page" layout="jh_test_layout" />
-    <view name="jh_test2" label="Another Landing Page" layout="jh_mest_layout" />
+    <view name="JH_LANDING" label="Landing Category" layout="jh_category_landing" />
 </views>

--- a/etc/landing_categories.xsd
+++ b/etc/landing_categories.xsd
@@ -1,12 +1,13 @@
 <?xml version="1.0" ?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-<xs:element name="config">
-    <xs:complexType>
-        <xs:sequence>
-            <xs:element minOccurs="1" maxOccurs="unbounded" name="view" type="viewDeclaration" />
-        </xs:sequence>
-    </xs:complexType>
-</xs:element>
+    <xs:element name="views">
+        <xs:complexType>
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="view" type="viewDeclaration" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
     <xs:complexType name="viewDeclaration">
         <xs:annotation>
             <xs:documentation>

--- a/etc/landing_categories.xsd
+++ b/etc/landing_categories.xsd
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:element name="config">
+    <xs:complexType>
+        <xs:sequence>
+            <xs:element minOccurs="1" maxOccurs="unbounded" name="view" type="viewDeclaration" />
+        </xs:sequence>
+    </xs:complexType>
+</xs:element>
+    <xs:complexType name="viewDeclaration">
+        <xs:annotation>
+            <xs:documentation>
+                View declaration
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="label" type="xs:string" use="required" />
+        <xs:attribute name="layout" type="xs:string" use="required" />
+    </xs:complexType>
+</xs:schema>

--- a/etc/landing_categories.xsd
+++ b/etc/landing_categories.xsd
@@ -6,8 +6,11 @@
                 <xs:element name="view" type="viewDeclaration" />
             </xs:sequence>
         </xs:complexType>
+        <xs:unique name="uniqueViewName">
+            <xs:selector xpath="view"/>
+            <xs:field xpath="@name"/>
+        </xs:unique>
     </xs:element>
-
     <xs:complexType name="viewDeclaration">
         <xs:annotation>
             <xs:documentation>

--- a/view/frontend/layout/jh_test_layout.xml
+++ b/view/frontend/layout/jh_test_layout.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="div.sidebar.main" remove="true"/>
+    </body>
+</page>

--- a/view/frontend/layout/jh_test_layout.xml
+++ b/view/frontend/layout/jh_test_layout.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-    <body>
-        <referenceContainer name="div.sidebar.main" remove="true"/>
-    </body>
-</page>


### PR DESCRIPTION
This adds the ability to configure different landing category pages using a custom config file `layout_categories.xml` which is read and then injected into the same functionality that the module currently uses but this makes it driven by config values instead of hardcoded. (which was not a requirement at the time but now it is so yeah)