### PR TITLE
Use layout instead of name as the handle value

### DIFF
--- a/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
+++ b/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
@@ -53,7 +53,7 @@ class Layout extends MainLayout
                 $newOptions = [];
                 foreach ($this->landingCategoryData->get() as $landingData) {
                     $newOptions[] = [
-                        'value' => $landingData['name'],
+                        'value' => $landingData['layout'],
                         'label' => $this->escapeJs(__($landingData['label']))
                     ];
                 }

--- a/Observer/Layout/LoadBeforeObserver.php
+++ b/Observer/Layout/LoadBeforeObserver.php
@@ -64,7 +64,7 @@ class LoadBeforeObserver implements ObserverInterface
         $categoryData = $this->categoryData->get();
 
         foreach ($categoryData as $key => $value) {
-            if ($value["name"] === $displayMode) {
+            if ($value["layout"] === $displayMode) {
                 return $value;
             }
         }

--- a/Plugin/Category/Attribute/Source/ModePlugin.php
+++ b/Plugin/Category/Attribute/Source/ModePlugin.php
@@ -31,7 +31,7 @@ class ModePlugin
         if (is_array($result)) {
             $catData = $this->landingCategoryData->get();
             foreach ($catData as $option) {
-                $result[] = ['value' => $option['name'], 'label' => $option['label']];
+                $result[] = ['value' => $option['layout'], 'label' => $option['label']];
             }
         }
         return $result;


### PR DESCRIPTION
In various places we we're using the `name` of the "view" as the reference, when actually we should probably be using the `layout`

If we don't then the handle we need would actually be `JH_LANDING.xml` which is odd, especially when we expect it to be the value of `layout` in the default case `jh_category_landing`

This also breaks on the admin JS side when selecting the landing page layout option as the container name differs to the dropdown value,  `JH_LANDING` vs `jh_category_landing`